### PR TITLE
Set the this-command to the real command executed

### DIFF
--- a/one-key.el
+++ b/one-key.el
@@ -383,6 +383,7 @@ last command when it miss match in key alist."
                   protect-function
                   alternate-function
                   execute-last-command-when-miss-match))))
+        (command-executed this-command)
         last-key)
     ;; Popup help window when first time call
     ;; and option `one-key-popup-window' is `non-nil'.
@@ -423,6 +424,7 @@ last command when it miss match in key alist."
                          (setq one-key-menu-call-first-time t)
                          ;; Execute.
                          (call-interactively command)
+                         (setq command-executed command)
                          ;; Set `one-key-menu-call-first-time' with "nil".
                          (setq one-key-menu-call-first-time nil)
                          (throw 'match t)))
@@ -482,7 +484,10 @@ last command when it miss match in key alist."
       (when (and execute-last-command-when-miss-match
                  last-key)
         ;; Execute command corresponding last input key.
-        (one-key-execute-binding-command last-key)))))
+        (one-key-execute-binding-command last-key))
+
+      ;; Make sure this-command is the real command executed
+      (setq this-command command-executed))))
 
 (defun one-key-execute-binding-command (key)
   "Execute the command binding KEY."


### PR DESCRIPTION
Fixes manateelazycat/lsp-bridge#203

将 `this-command` 设为真正执行的命令。现在只是设置了正常菜单项执行的命令，其他的也没用过，暂时先不处理。